### PR TITLE
Fix rendering on HiDPI

### DIFF
--- a/pptk/viewer/main.cpp
+++ b/pptk/viewer/main.cpp
@@ -8,6 +8,7 @@ int main(int argc, char* argv[]) {
     qDebug() << "usage: viewer <port number>";
     return 1;
   }
+  QCoreApplication::setAttribute(Qt::AA_DisableHighDpiScaling);
   QApplication a(argc, argv);
   unsigned short clientPort = (unsigned short)atoi(argv[1]);
   Viewer viewer(clientPort);


### PR DESCRIPTION
This is a possible fix to #26, by disabling automatic DPI scaling in the Qt application and let the system handle it.

This is admittedly not tested on Windows or Mac.

Testing on Arch Linux, KDE, monitor resolution 3200x1800, scale factor set to 2.0 through KScreen settings.
```python
import numpy as np
import pptk
x = np.random.rand(100, 3)
v = pptk.viewer(x)
```
![Screenshot_20191128_122105](https://user-images.githubusercontent.com/8300317/69799033-2c7b2780-11db-11ea-8c6d-c294d5464fcc.png)

Resolves #26 